### PR TITLE
WIP: Fetch reputation for a given account

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 [[package]]
 name = "ac-compose-macros"
 version = "0.2.3"
-source = "git+https://github.com/scs/substrate-api-client.git?branch=polkadot-v0.9.42-tag-v0.10.0#686b7ef0aa8da255d3864a3fc703e32193813700"
+source = "git+https://github.com/scs/substrate-api-client.git?branch=polkadot-v0.9.42-tag-v0.10.0#6215a9e22e60f0651276d3cbf5a1c7fe0eaf84ed"
 dependencies = [
  "ac-primitives",
  "log 0.4.19",
@@ -28,7 +28,7 @@ dependencies = [
 [[package]]
 name = "ac-node-api"
 version = "0.2.3"
-source = "git+https://github.com/scs/substrate-api-client.git?branch=polkadot-v0.9.42-tag-v0.10.0#686b7ef0aa8da255d3864a3fc703e32193813700"
+source = "git+https://github.com/scs/substrate-api-client.git?branch=polkadot-v0.9.42-tag-v0.10.0#6215a9e22e60f0651276d3cbf5a1c7fe0eaf84ed"
 dependencies = [
  "ac-primitives",
  "bitvec",
@@ -40,7 +40,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde 1.0.164",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "sp-application-crypto",
  "sp-core",
  "sp-runtime",
@@ -50,7 +50,7 @@ dependencies = [
 [[package]]
 name = "ac-primitives"
 version = "0.5.0"
-source = "git+https://github.com/scs/substrate-api-client.git?branch=polkadot-v0.9.42-tag-v0.10.0#686b7ef0aa8da255d3864a3fc703e32193813700"
+source = "git+https://github.com/scs/substrate-api-client.git?branch=polkadot-v0.9.42-tag-v0.10.0#6215a9e22e60f0651276d3cbf5a1c7fe0eaf84ed"
 dependencies = [
  "frame-system",
  "hex",
@@ -63,7 +63,7 @@ dependencies = [
  "primitive-types",
  "scale-info",
  "serde 1.0.164",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "sp-core",
  "sp-runtime",
  "sp-staking",
@@ -86,7 +86,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
 dependencies = [
- "gimli 0.27.2",
+ "gimli 0.27.3",
 ]
 
 [[package]]
@@ -645,7 +645,7 @@ dependencies = [
  "cargo-platform",
  "semver 1.0.17",
  "serde 1.0.164",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "thiserror 1.0.40",
 ]
 
@@ -887,9 +887,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
+checksum = "03e69e28e9f7f77debdedbaafa2866e1de9ba56df55a8bd7cfc724c25a09987c"
 dependencies = [
  "libc",
 ]
@@ -1040,9 +1040,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109308c20e8445959c2792e81871054c6a17e6976489a93d2769641a2ba5839c"
+checksum = "e88abab2f5abbe4c56e8f1fb431b784d710b709888f35755a160e62e33fe38e8"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -1052,9 +1052,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf4c6755cdf10798b97510e0e2b3edb9573032bd9379de8fffa59d68165494f"
+checksum = "5c0c11acd0e63bae27dcd2afced407063312771212b7a823b4fd72d633be30fb"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -1067,15 +1067,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882074421238e84fe3b4c65d0081de34e5b323bf64555d3e61991f76eb64a7bb"
+checksum = "8d3816ed957c008ccd4728485511e3d9aaf7db419aa321e3d2c5a2f3411e36c8"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a076022ece33e7686fb76513518e219cca4fce5750a8ae6d1ce6c0f48fd1af9"
+checksum = "a26acccf6f445af85ea056362561a24ef56cdc15fcc685f03aec50b9c702cb6d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1799,7 +1799,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "15.1.0"
-source = "git+https://github.com/paritytech/frame-metadata#0c6400964fe600ea07f8233810415f6958fe4e20"
+source = "git+https://github.com/paritytech/frame-metadata#d6e6c2bf820bd2067aadd7420f361cacaddbb09e"
 dependencies = [
  "cfg-if 1.0.0",
  "parity-scale-codec",
@@ -2215,9 +2215,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.2"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
 name = "glob"
@@ -2756,7 +2756,7 @@ dependencies = [
  "rayon",
  "sc-keystore",
  "serde 1.0.164",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "sgx_crypto_helper",
  "sp-application-crypto",
  "sp-core",
@@ -2863,7 +2863,7 @@ dependencies = [
  "scale-info",
  "serde 1.0.164",
  "serde_derive 1.0.164",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "sgx-verify",
  "sgx_crypto_helper",
  "sgx_types",
@@ -2924,7 +2924,7 @@ dependencies = [
  "hyper-tls",
  "parity-multiaddr",
  "serde 1.0.164",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "serde_urlencoded",
  "tokio",
  "tokio-util 0.6.10",
@@ -2956,7 +2956,7 @@ dependencies = [
  "log 0.4.19",
  "parity-scale-codec",
  "serde 1.0.164",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "sgx_tstd",
  "substrate-fixed",
  "thiserror 1.0.40",
@@ -3049,7 +3049,7 @@ dependencies = [
  "jsonrpc-core 18.0.0 (git+https://github.com/scs/jsonrpc?branch=no_std_v18)",
  "log 0.4.19",
  "parity-scale-codec",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "sgx_tstd",
  "sgx_types",
  "sp-runtime",
@@ -3219,7 +3219,7 @@ dependencies = [
  "http_req 0.8.1 (git+https://github.com/integritee-network/http_req)",
  "log 0.4.19",
  "serde 1.0.164",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "sgx_tstd",
  "sgx_types",
  "thiserror 1.0.40",
@@ -3246,7 +3246,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "rustls 0.19.1",
  "serde_derive 1.0.164",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "sgx_crypto_helper",
  "thiserror 1.0.40",
  "url 2.4.0",
@@ -3270,7 +3270,7 @@ dependencies = [
  "jsonrpsee",
  "log 0.4.19",
  "parity-scale-codec",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "sp-core",
  "tokio",
 ]
@@ -3377,7 +3377,7 @@ dependencies = [
  "rustls 0.19.0 (git+https://github.com/mesalock-linux/rustls?rev=sgx_1.1.3)",
  "rustls 0.19.1",
  "serde_json 1.0.60 (git+https://github.com/mesalock-linux/serde-json-sgx?tag=sgx_1.1.3)",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "sgx_rand",
  "sgx_tcrypto",
  "sgx_tse",
@@ -3415,7 +3415,7 @@ dependencies = [
  "itp-types",
  "log 0.4.19",
  "parity-scale-codec",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "sgx_crypto_helper",
  "sgx_types",
  "sgx_urts",
@@ -3565,7 +3565,7 @@ dependencies = [
  "itp-types",
  "parity-scale-codec",
  "serde 1.0.164",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "sgx_tstd",
 ]
 
@@ -3588,7 +3588,7 @@ dependencies = [
  "serde 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx?tag=sgx_1.1.3)",
  "serde 1.0.164",
  "serde_json 1.0.60 (git+https://github.com/mesalock-linux/serde-json-sgx?tag=sgx_1.1.3)",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "sgx_crypto_helper",
  "sgx_rand",
  "sgx_tstd",
@@ -3855,7 +3855,7 @@ dependencies = [
  "parity-scale-codec",
  "primitive-types",
  "serde 1.0.164",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "sp-core",
  "sp-runtime",
  "sp-std",
@@ -4032,7 +4032,7 @@ dependencies = [
  "jsonrpsee",
  "log 0.4.19",
  "serde 1.0.164",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "thiserror 1.0.40",
  "tokio",
 ]
@@ -4184,7 +4184,7 @@ dependencies = [
  "log 0.4.19",
  "serde 1.0.164",
  "serde_derive 1.0.164",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
 ]
 
 [[package]]
@@ -4228,7 +4228,7 @@ dependencies = [
  "jsonrpsee-utils",
  "log 0.4.19",
  "serde 1.0.164",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "thiserror 1.0.40",
  "url 2.4.0",
 ]
@@ -4248,7 +4248,7 @@ dependencies = [
  "lazy_static",
  "log 0.4.19",
  "serde 1.0.164",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "socket2",
  "thiserror 1.0.40",
  "tokio",
@@ -4281,7 +4281,7 @@ dependencies = [
  "hyper",
  "log 0.4.19",
  "serde 1.0.164",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "soketto",
  "thiserror 1.0.40",
 ]
@@ -4301,7 +4301,7 @@ dependencies = [
  "rand 0.8.5",
  "rustc-hash",
  "serde 1.0.164",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "thiserror 1.0.40",
 ]
 
@@ -4320,7 +4320,7 @@ dependencies = [
  "rustls 0.19.1",
  "rustls-native-certs",
  "serde 1.0.164",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "soketto",
  "thiserror 1.0.40",
  "tokio",
@@ -4342,7 +4342,7 @@ dependencies = [
  "log 0.4.19",
  "rustc-hash",
  "serde 1.0.164",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "soketto",
  "thiserror 1.0.40",
  "tokio",
@@ -4360,7 +4360,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell 1.18.0",
- "sha2 0.10.6",
+ "sha2 0.10.7",
 ]
 
 [[package]]
@@ -4728,7 +4728,7 @@ dependencies = [
  "libc",
  "log 0.4.19",
  "miow",
- "net2 0.2.38",
+ "net2 0.2.39",
  "slab 0.4.8",
  "winapi 0.2.8",
 ]
@@ -4777,7 +4777,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
 dependencies = [
  "kernel32-sys",
- "net2 0.2.38",
+ "net2 0.2.39",
  "winapi 0.2.8",
  "ws2_32-sys",
 ]
@@ -4909,9 +4909,9 @@ dependencies = [
 
 [[package]]
 name = "net2"
-version = "0.2.38"
+version = "0.2.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d0df99cfcd2530b2e694f6e17e7f37b8e26bb23983ac530c0c97408837c631"
+checksum = "b13b648036a2339d06de780866fbdfda0dde886de7b3af2ddeba8b14f4ee34ac"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
@@ -5783,9 +5783,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.5.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ddb756ca205bd108aee3c62c6d3c994e1df84a59b9d6d4a5ea42ee1fd5a9a28"
+checksum = "430d26d62e66cbff6ae144e8eebd43c0235922dec7e3aa0d2016c32d4575bf45"
 dependencies = [
  "arrayvec 0.7.3",
  "bitvec",
@@ -5798,9 +5798,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.1.4"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b26a931f824dd4eca30b3e43bb4f31cd5f0d3a403c5f5ff27106b805bfde7b"
+checksum = "a1620b1e3fc72ebaee01ff56fca838bab537c5d093a18b3549c3bbea374aa0b6"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6806,7 +6806,7 @@ dependencies = [
  "array-bytes 4.2.0",
  "async-trait",
  "parking_lot 0.12.1",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "sp-application-crypto",
  "sp-core",
  "sp-keystore",
@@ -7103,9 +7103,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.96"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
+checksum = "bdf3bf93142acad5821c99197022e170842cdbc1c30482b98750c688c640842a"
 dependencies = [
  "indexmap 1.9.3",
  "itoa 1.0.6",
@@ -7149,7 +7149,7 @@ dependencies = [
  "ring 0.16.20 (git+https://github.com/Niederb/ring-xous.git?branch=0.16.20-cleanup)",
  "scale-info",
  "serde 1.0.164",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "sp-core",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.42)",
  "sp-std",
@@ -7386,9 +7386,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
@@ -7716,7 +7716,7 @@ dependencies = [
  "blake2b_simd",
  "byteorder 1.4.3",
  "digest 0.10.7",
- "sha2 0.10.6",
+ "sha2 0.10.7",
  "sha3",
  "sp-std",
  "twox-hash",
@@ -8173,7 +8173,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde 1.0.164",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "unicode-xid",
 ]
 
@@ -8226,7 +8226,7 @@ dependencies = [
 [[package]]
 name = "substrate-api-client"
 version = "0.10.0"
-source = "git+https://github.com/scs/substrate-api-client.git?branch=polkadot-v0.9.42-tag-v0.10.0#686b7ef0aa8da255d3864a3fc703e32193813700"
+source = "git+https://github.com/scs/substrate-api-client.git?branch=polkadot-v0.9.42-tag-v0.10.0#6215a9e22e60f0651276d3cbf5a1c7fe0eaf84ed"
 dependencies = [
  "ac-compose-macros",
  "ac-node-api",
@@ -8238,7 +8238,7 @@ dependencies = [
  "log 0.4.19",
  "parity-scale-codec",
  "serde 1.0.164",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "sp-core",
  "sp-runtime",
  "sp-runtime-interface",
@@ -8262,13 +8262,13 @@ dependencies = [
 [[package]]
 name = "substrate-client-keystore"
 version = "0.7.0"
-source = "git+https://github.com/scs/substrate-api-client.git?branch=polkadot-v0.9.42-tag-v0.10.0#686b7ef0aa8da255d3864a3fc703e32193813700"
+source = "git+https://github.com/scs/substrate-api-client.git?branch=polkadot-v0.9.42-tag-v0.10.0#6215a9e22e60f0651276d3cbf5a1c7fe0eaf84ed"
 dependencies = [
  "array-bytes 4.2.0",
  "async-trait",
  "parking_lot 0.12.1",
  "sc-keystore",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "sp-application-crypto",
  "sp-core",
  "sp-keyring",
@@ -8501,7 +8501,7 @@ dependencies = [
  "pbkdf2 0.11.0",
  "rand 0.8.5",
  "rustc-hash",
- "sha2 0.10.6",
+ "sha2 0.10.7",
  "thiserror 1.0.40",
  "unicode-normalization 0.1.22",
  "wasm-bindgen",
@@ -8742,7 +8742,7 @@ dependencies = [
  "matchers",
  "regex 1.8.4",
  "serde 1.0.164",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "sharded-slab",
  "smallvec 1.10.0",
  "thread_local",
@@ -9067,11 +9067,10 @@ dependencies = [
 
 [[package]]
 name = "want"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
- "log 0.4.19",
  "try-lock",
 ]
 
@@ -9096,7 +9095,7 @@ dependencies = [
  "rustls-pemfile",
  "scoped-tls",
  "serde 1.0.164",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "serde_urlencoded",
  "tokio",
  "tokio-stream",
@@ -9720,9 +9719,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
+checksum = "ca0ace3845f0d96209f0375e6d367e3eb87eb65d27d445bdc9f1843a26f39448"
 dependencies = [
  "memchr 2.5.0",
 ]
@@ -9779,18 +9778,18 @@ dependencies = [
 
 [[package]]
 name = "xous"
-version = "0.9.44"
+version = "0.9.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30684dda3583f528d5b05bddc96527e1783255e867a5e81c10721d6abb9e169c"
+checksum = "648387c0ac9e051154d7b9fa56ce5845bffa576387ed2b18a3b5977341c77982"
 dependencies = [
  "lazy_static",
 ]
 
 [[package]]
 name = "xous-api-log"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6b15ea09891f09b02d763422dc99733c96e62d0f8ab476c6bc663c90b17e72"
+checksum = "24aad5ecdee87526a97eaaa7f26d22c0fe419667727598d694bda183dfa31847"
 dependencies = [
  "log 0.4.19",
  "num-derive",
@@ -9801,9 +9800,9 @@ dependencies = [
 
 [[package]]
 name = "xous-api-names"
-version = "0.9.42"
+version = "0.9.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b470fbf177d58767fa001acfcb5294a88d3938d3935865ff6b8f1db40f1004e"
+checksum = "92baa5a52f91e40d015a53db1891c66ee7c715b22d1e9731a6fb29e3d9df1061"
 dependencies = [
  "log 0.4.19",
  "num-derive",
@@ -9816,9 +9815,9 @@ dependencies = [
 
 [[package]]
 name = "xous-ipc"
-version = "0.9.44"
+version = "0.9.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d520fe08642d55a56f700b6d30c7a556f38818e7c3e5d9a0856dde0b79ed4d67"
+checksum = "510be937e654eeed0b60f627b4615e7a89e3cba88e20f1198ed16a87ea4b5fde"
 dependencies = [
  "bitflags",
  "rkyv",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ source = "git+https://github.com/scs/substrate-api-client.git?branch=polkadot-v0
 dependencies = [
  "frame-system",
  "hex",
- "impl-serde",
+ "impl-serde 0.4.0",
  "pallet-assets",
  "pallet-balances",
  "pallet-contracts",
@@ -904,6 +904,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49fc9a695bca7f35f5f4c15cddc84415f66a74ea78eef08e90c5024f2b540e23"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccaeedb56da03b09f598226e25e80088cb4cd25f316e6e4df7d695f0feeb1403"
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1333,6 +1348,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "encointer-primitives"
+version = "1.2.0"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v0.9.42#e443bdd15f38f76f01c1f17732ce8376708556f7"
+dependencies = [
+ "bs58",
+ "crc",
+ "ep-core",
+ "frame-support",
+ "geohash",
+ "log 0.4.19",
+ "parity-scale-codec",
+ "scale-info",
+ "serde 1.0.164",
+ "sp-core",
+ "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.42)",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1372,6 +1407,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48c92028aaa870e83d51c64e5d4e0b6981b360c522198c23959f219a4e1b15b"
 
 [[package]]
+name = "ep-core"
+version = "1.2.0"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v0.9.42#e443bdd15f38f76f01c1f17732ce8376708556f7"
+dependencies = [
+ "impl-serde 0.3.2",
+ "parity-scale-codec",
+ "scale-info",
+ "serde 1.0.164",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
+ "substrate-fixed",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1402,7 +1453,7 @@ dependencies = [
  "fixed-hash",
  "impl-codec",
  "impl-rlp",
- "impl-serde",
+ "impl-serde 0.4.0",
  "scale-info",
  "tiny-keccak",
 ]
@@ -1435,7 +1486,7 @@ dependencies = [
  "fixed-hash",
  "impl-codec",
  "impl-rlp",
- "impl-serde",
+ "impl-serde 0.4.0",
  "primitive-types",
  "scale-info",
  "uint",
@@ -1682,7 +1733,7 @@ version = "1.0.0-dev"
 source = "git+https://github.com/integritee-network/frontier.git?branch=bar/polkadot-v0.9.42#a5a5e1e6ec08cd542a6084c310863150fb8841b1"
 dependencies = [
  "hex",
- "impl-serde",
+ "impl-serde 0.4.0",
  "libsecp256k1",
  "log 0.4.19",
  "parity-scale-codec",
@@ -2168,6 +2219,16 @@ dependencies = [
  "typenum 1.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check",
  "zeroize",
+]
+
+[[package]]
+name = "geohash"
+version = "0.13.0"
+source = "git+https://github.com/encointer/geohash?tag=v0.13.0#ad60d861f6bdbfd96ee9318f82554a7bec3089af"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "substrate-fixed",
 ]
 
 [[package]]
@@ -2660,6 +2721,15 @@ dependencies = [
 
 [[package]]
 name = "impl-serde"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4551f042f3438e64dbd6226b20527fc84a6e1fe65688b58746a2f53623f25f5c"
+dependencies = [
+ "serde 1.0.164",
+]
+
+[[package]]
+name = "impl-serde"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
@@ -2732,6 +2802,7 @@ dependencies = [
  "blake2-rfc",
  "chrono 0.4.26",
  "clap 3.2.25",
+ "encointer-primitives",
  "env_logger 0.9.3",
  "frame-system",
  "hdrhistogram",
@@ -2824,6 +2895,7 @@ dependencies = [
  "base58",
  "clap 2.34.0",
  "dirs",
+ "encointer-primitives",
  "env_logger 0.9.3",
  "frame-support",
  "frame-system",
@@ -6072,7 +6144,7 @@ dependencies = [
  "fixed-hash",
  "impl-codec",
  "impl-rlp",
- "impl-serde",
+ "impl-serde 0.4.0",
  "scale-info",
  "uint",
 ]
@@ -7679,7 +7751,7 @@ dependencies = [
  "futures 0.3.28",
  "hash-db 0.16.0",
  "hash256-std-hasher",
- "impl-serde",
+ "impl-serde 0.4.0",
  "lazy_static",
  "libsecp256k1",
  "log 0.4.19",
@@ -8006,7 +8078,7 @@ name = "sp-storage"
 version = "7.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.42#569aae5341ea0c1d10426fa1ec13a36c0b64393b"
 dependencies = [
- "impl-serde",
+ "impl-serde 0.4.0",
  "parity-scale-codec",
  "ref-cast",
  "serde 1.0.164",
@@ -8078,7 +8150,7 @@ name = "sp-version"
 version = "5.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.42#569aae5341ea0c1d10426fa1ec13a36c0b64393b"
 dependencies = [
- "impl-serde",
+ "impl-serde 0.4.0",
  "parity-scale-codec",
  "parity-wasm",
  "scale-info",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -33,6 +33,8 @@ substrate-api-client = { default-features = false, features = ["std", "ws-client
 substrate-client-keystore = { git = "https://github.com/scs/substrate-api-client.git", branch = "polkadot-v0.9.42-tag-v0.10.0" }
 teerex-primitives = { git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.42" }
 
+encointer-primitives = { branch = "polkadot-v0.9.42", git = "https://github.com/encointer/pallets", features = ["full_crypto"] }
+
 # substrate dependencies
 frame-system = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 pallet-balances = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -22,6 +22,9 @@ use clap::Subcommand;
 #[cfg(feature = "teeracle")]
 use crate::oracle::OracleCommand;
 
+#[cfg(feature = "teeracle")]
+use crate::personhood_oracle::PersonhoodOracleCommand;
+
 use crate::attesteer::AttesteerCommand;
 
 #[derive(Subcommand)]
@@ -41,6 +44,11 @@ pub enum Commands {
 	/// Subcommand for the attesteer.
 	#[clap(subcommand)]
 	Attesteer(AttesteerCommand),
+
+	/// Subcommand for the personhood oracle.
+	#[cfg(feature = "teeracle")]
+	#[clap(subcommand)]
+	PersonhoodOracle(PersonhoodOracleCommand),
 }
 
 pub fn match_command(cli: &Cli) -> CliResult {
@@ -53,6 +61,11 @@ pub fn match_command(cli: &Cli) -> CliResult {
 			Ok(CliResultOk::None)
 		},
 		Commands::Attesteer(cmd) => {
+			cmd.run(cli);
+			Ok(CliResultOk::None)
+		},
+		#[cfg(feature = "teeracle")]
+		Commands::PersonhoodOracle(cmd) => {
 			cmd.run(cli);
 			Ok(CliResultOk::None)
 		},

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -36,6 +36,8 @@ mod error;
 mod evm;
 #[cfg(feature = "teeracle")]
 mod oracle;
+#[cfg(feature = "teeracle")]
+mod personhood_oracle;
 mod trusted_base_cli;
 mod trusted_cli;
 mod trusted_command_utils;

--- a/cli/src/oracle/commands/fetch_nostr.rs
+++ b/cli/src/oracle/commands/fetch_nostr.rs
@@ -1,0 +1,100 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+use crate::Cli;
+
+#[derive(Debug, Clone, Parser)]
+pub struct FetchNostrCmd {
+	pub value: String,
+}
+
+impl FetchNostrCmd {
+	pub fn run(&self, cli: &Cli) {}
+
+	fn fetch_brenzi() {
+		use nostr::prelude::*;
+		use tungstenite::Message as WsMessage;
+
+		// From https://gist.github.com/brenzi/32e9109599ea659a3d7277bfe2e8b9c7
+		// Generate new random keys
+		//let my_keys = Keys::generate();
+
+		// or use your already existing
+		//
+		// From HEX or Bech32
+		let my_keys =
+			Keys::from_sk_str("nsec13wqyx0syeu7unce6d7p8x4rqqe7elpfpr9ywsl5y6x427dzj8tyq36ku2r")
+				.unwrap();
+
+		// Show bech32 public key
+		let bech32_pubkey: String = my_keys.public_key().to_bech32().unwrap();
+		println!("Bech32 PubKey: {}", bech32_pubkey);
+		println!("Secret key: {}", my_keys.secret_key().unwrap().to_bech32().unwrap());
+
+		let metadata = Metadata::new()
+			.name("somediddelidoo")
+			.display_name("Some Diddelidoo")
+			.about("I'm just testing");
+
+		let event: Event = EventBuilder::set_metadata(metadata).to_event(&my_keys).unwrap();
+
+		// New text note
+		let event: Event = EventBuilder::new_text_note("Hello from Nostr SDK", &[])
+			.to_event(&my_keys)
+			.unwrap();
+
+		// Connect to relay
+		let (mut socket, _) =
+			tungstenite::connect("wss://relay.damus.io").expect("Can't connect to relay");
+
+		println!("sending text message with id {}", event.id.to_bech32().unwrap());
+
+		// Send msg
+		let msg = ClientMessage::new_event(event).as_json();
+		socket.write_message(WsMessage::Text(msg)).expect("Impossible to send message");
+
+		/*
+			// create channel
+			let metadata = Metadata::new()
+				.name("diddelichannel")
+				.about("I'm just testing")
+				.picture(Url::parse("https://placekitten.com/200/200").unwrap());
+			let event: Event = EventBuilder::new_channel(metadata).unwrap().to_event(&my_keys).unwrap();
+			println!("creating channel with ID {}", event.id.to_bech32().unwrap());
+			let msg = ClientMessage::new_event(event).as_json();
+
+			socket.write_message(WsMessage::Text(msg)).expect("Impossible to send message");
+		*/
+		let channel_id = ChannelId::from(
+			EventId::from_bech32("note18kst54gwje8n5t3cfpdud4duwh37wtfu4zpefd6a6q24nc2uecqs6vy8lq")
+				.unwrap(),
+		);
+
+		println!("posting a message to channel {}", channel_id);
+
+		let event: Event = EventBuilder::new_channel_msg(
+			channel_id,
+			nostr::Url::parse("wss://relay.damus.io").unwrap(),
+			"post in channel",
+		)
+		.to_event(&my_keys)
+		.unwrap();
+
+		let msg = ClientMessage::new_event(event).as_json();
+
+		socket.write_message(WsMessage::Text(msg)).expect("Impossible to send message");
+	}
+}

--- a/cli/src/personhood_oracle/commands/fetch_reputation.rs
+++ b/cli/src/personhood_oracle/commands/fetch_reputation.rs
@@ -1,0 +1,62 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+		http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+use crate::{
+	command_utils::{get_accountid_from_str, get_chain_api},
+	Cli,
+};
+use encointer_primitives::{
+	ceremonies::Reputation, communities::CommunityIdentifier, scheduler::CeremonyIndexType,
+};
+use itp_node_api::api_client::ParentchainApi;
+use my_node_runtime::AccountId;
+use std::str::FromStr;
+use substrate_api_client::GetStorage;
+
+#[derive(Debug, Clone, Parser)]
+pub struct FetchReputationCmd {
+	pub account: String,
+	pub cid: String,
+	pub cindex: CeremonyIndexType,
+}
+
+impl FetchReputationCmd {
+	pub fn run(&self, cli: &Cli) {
+		let api = get_chain_api(&cli);
+		let cid = CommunityIdentifier::from_str(&self.cid).unwrap();
+		let cindex = self.cindex;
+		let account = get_accountid_from_str(&self.account);
+
+		let reputation = get_reputation(&api, &account, cid, cindex);
+
+		println!("reputation for {} is: {:#?}", account, reputation);
+	}
+}
+
+pub fn get_reputation(
+	api: &ParentchainApi,
+	prover: &AccountId,
+	cid: CommunityIdentifier,
+	cindex: CeremonyIndexType,
+) -> Reputation {
+	api.get_storage_double_map(
+		"EncointerCeremonies",
+		"ParticipantReputation",
+		(cid, cindex),
+		prover.clone(),
+		None,
+	)
+	.unwrap()
+	.or(Some(Reputation::Unverified))
+	.unwrap()
+}

--- a/cli/src/personhood_oracle/commands/mod.rs
+++ b/cli/src/personhood_oracle/commands/mod.rs
@@ -1,0 +1,20 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+mod fetch_reputation;
+
+pub use self::fetch_reputation::FetchReputationCmd;

--- a/cli/src/personhood_oracle/mod.rs
+++ b/cli/src/personhood_oracle/mod.rs
@@ -1,0 +1,37 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+use crate::{
+	personhood_oracle::{commands::FetchReputationCmd, PersonhoodOracleCommand::FetchReputation},
+	Cli,
+};
+
+mod commands;
+
+/// Oracle subcommands for the cli.
+#[derive(Debug, clap::Subcommand)]
+pub enum PersonhoodOracleCommand {
+	FetchReputation(FetchReputationCmd),
+}
+
+impl PersonhoodOracleCommand {
+	pub fn run(&self, cli: &Cli) {
+		match self {
+			FetchReputation(FetchReputationCmd) => FetchReputationCmd.run(&cli),
+		}
+	}
+}

--- a/cli/src/personhood_oracle/mod.rs
+++ b/cli/src/personhood_oracle/mod.rs
@@ -31,7 +31,7 @@ pub enum PersonhoodOracleCommand {
 impl PersonhoodOracleCommand {
 	pub fn run(&self, cli: &Cli) {
 		match self {
-			FetchReputation(FetchReputationCmd) => FetchReputationCmd.run(&cli),
+			FetchReputation(fetch_reputation_cmd) => fetch_reputation_cmd.run(&cli),
 		}
 	}
 }

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 [[package]]
 name = "ac-compose-macros"
 version = "0.2.3"
-source = "git+https://github.com/scs/substrate-api-client.git?branch=polkadot-v0.9.42-tag-v0.10.0#686b7ef0aa8da255d3864a3fc703e32193813700"
+source = "git+https://github.com/scs/substrate-api-client.git?branch=polkadot-v0.9.42-tag-v0.10.0#6215a9e22e60f0651276d3cbf5a1c7fe0eaf84ed"
 dependencies = [
  "ac-primitives",
  "log",
@@ -28,7 +28,7 @@ dependencies = [
 [[package]]
 name = "ac-node-api"
 version = "0.2.3"
-source = "git+https://github.com/scs/substrate-api-client.git?branch=polkadot-v0.9.42-tag-v0.10.0#686b7ef0aa8da255d3864a3fc703e32193813700"
+source = "git+https://github.com/scs/substrate-api-client.git?branch=polkadot-v0.9.42-tag-v0.10.0#6215a9e22e60f0651276d3cbf5a1c7fe0eaf84ed"
 dependencies = [
  "ac-primitives",
  "bitvec",
@@ -40,7 +40,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde 1.0.164",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "sp-application-crypto",
  "sp-core",
  "sp-runtime",
@@ -50,7 +50,7 @@ dependencies = [
 [[package]]
 name = "ac-primitives"
 version = "0.5.0"
-source = "git+https://github.com/scs/substrate-api-client.git?branch=polkadot-v0.9.42-tag-v0.10.0#686b7ef0aa8da255d3864a3fc703e32193813700"
+source = "git+https://github.com/scs/substrate-api-client.git?branch=polkadot-v0.9.42-tag-v0.10.0#6215a9e22e60f0651276d3cbf5a1c7fe0eaf84ed"
 dependencies = [
  "hex",
  "impl-serde",
@@ -58,7 +58,7 @@ dependencies = [
  "primitive-types",
  "scale-info",
  "serde 1.0.164",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "sp-core",
  "sp-runtime",
  "sp-staking",
@@ -169,9 +169,9 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+checksum = "8868f09ff8cea88b079da74ae569d9b8c62a23c68c746240b704ee6f7525c89c"
 
 [[package]]
 name = "auto_impl"
@@ -300,8 +300,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c2f0dc9a68c6317d884f97cc36cf5a3d20ba14ce404227df55e1af708ab04bc"
 dependencies = [
  "arrayref",
- "arrayvec 0.7.2",
- "constant_time_eq 0.2.5",
+ "arrayvec 0.7.3",
+ "constant_time_eq 0.2.6",
 ]
 
 [[package]]
@@ -363,9 +363,9 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bounded-collections"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07fbd1d11282a1eb134d3c3b7cf8ce213b5161c6e5f73fb1b98618482c606b64"
+checksum = "eb5b05133427c07c4776906f673ccf36c21b102c9829c641a5b56bd151d44fd6"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -498,9 +498,9 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "constant_time_eq"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13418e745008f7349ec7e449155f419a61b92b58a99cc3616942b926825ec76b"
+checksum = "21a53c0a4d288377e7415b53dcfc3c04da5cdc2cc95c8d5ac178b58f0b861ad6"
 
 [[package]]
 name = "convert_case"
@@ -510,12 +510,27 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
+checksum = "03e69e28e9f7f77debdedbaafa2866e1de9ba56df55a8bd7cfc724c25a09987c"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49fc9a695bca7f35f5f4c15cddc84415f66a74ea78eef08e90c5024f2b540e23"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccaeedb56da03b09f598226e25e80088cb4cd25f316e6e4df7d695f0feeb1403"
 
 [[package]]
 name = "crunchy"
@@ -699,6 +714,7 @@ dependencies = [
  "array-bytes 6.1.0",
  "cid",
  "derive_more",
+ "encointer-primitives",
  "env_logger",
  "frame-support",
  "frame-system",
@@ -774,6 +790,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "encointer-primitives"
+version = "1.2.0"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v0.9.42#e443bdd15f38f76f01c1f17732ce8376708556f7"
+dependencies = [
+ "bs58",
+ "crc",
+ "ep-core",
+ "frame-support",
+ "geohash",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.9.0"
 source = "git+https://github.com/integritee-network/env_logger-sgx#55745829b2ae8a77f0915af3671ec8a9a00cace9"
@@ -797,6 +832,20 @@ name = "environmental"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48c92028aaa870e83d51c64e5d4e0b6981b360c522198c23959f219a4e1b15b"
+
+[[package]]
+name = "ep-core"
+version = "1.2.0"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v0.9.42#e443bdd15f38f76f01c1f17732ce8376708556f7"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
+ "substrate-fixed",
+]
 
 [[package]]
 name = "ethbloom"
@@ -1026,7 +1075,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "15.1.0"
-source = "git+https://github.com/paritytech/frame-metadata#0c6400964fe600ea07f8233810415f6958fe4e20"
+source = "git+https://github.com/paritytech/frame-metadata#d6e6c2bf820bd2067aadd7420f361cacaddbb09e"
 dependencies = [
  "cfg-if 1.0.0",
  "parity-scale-codec",
@@ -1319,6 +1368,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "geohash"
+version = "0.13.0"
+source = "git+https://github.com/encointer/geohash?tag=v0.13.0#ad60d861f6bdbfd96ee9318f82554a7bec3089af"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "substrate-fixed",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.14"
 source = "git+https://github.com/mesalock-linux/getrandom-sgx#0aa9cc20c7dea713ccaac2c44430d625a395ebae"
@@ -1572,7 +1631,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "serde 1.0.164",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "sgx_tstd",
  "substrate-fixed",
  "thiserror 1.0.9",
@@ -1656,7 +1715,7 @@ dependencies = [
  "jsonrpc-core",
  "log",
  "parity-scale-codec",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "sgx_tstd",
  "sgx_types",
  "sp-runtime",
@@ -1807,7 +1866,7 @@ dependencies = [
  "http_req",
  "log",
  "serde 1.0.164",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "sgx_tstd",
  "sgx_types",
  "thiserror 1.0.9",
@@ -1872,7 +1931,7 @@ dependencies = [
 name = "itp-attestation-handler"
 version = "0.8.0"
 dependencies = [
- "arrayvec 0.7.2",
+ "arrayvec 0.7.3",
  "base64 0.13.0 (git+https://github.com/mesalock-linux/rust-base64-sgx?rev=sgx_1.1.3)",
  "bit-vec",
  "chrono 0.4.11",
@@ -2020,7 +2079,7 @@ dependencies = [
  "itp-types",
  "parity-scale-codec",
  "serde 1.0.164",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "sgx_tstd",
 ]
 
@@ -2291,7 +2350,7 @@ dependencies = [
  "parity-scale-codec",
  "primitive-types",
  "serde 1.0.164",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "sp-core",
  "sp-runtime",
  "sp-std",
@@ -2530,7 +2589,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "ecdsa",
  "elliptic-curve",
- "sha2 0.10.6",
+ "sha2 0.10.7",
 ]
 
 [[package]]
@@ -3044,11 +3103,11 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.5.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ddb756ca205bd108aee3c62c6d3c994e1df84a59b9d6d4a5ea42ee1fd5a9a28"
+checksum = "430d26d62e66cbff6ae144e8eebd43c0235922dec7e3aa0d2016c32d4575bf45"
 dependencies = [
- "arrayvec 0.7.2",
+ "arrayvec 0.7.3",
  "bitvec",
  "byte-slice-cast",
  "bytes 1.4.0",
@@ -3059,9 +3118,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.1.4"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b26a931f824dd4eca30b3e43bb4f31cd5f0d3a403c5f5ff27106b805bfde7b"
+checksum = "a1620b1e3fc72ebaee01ff56fca838bab537c5d093a18b3549c3bbea374aa0b6"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -3683,9 +3742,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.96"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
+checksum = "bdf3bf93142acad5821c99197022e170842cdbc1c30482b98750c688c640842a"
 dependencies = [
  "itoa 1.0.6",
  "ryu",
@@ -3913,9 +3972,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
@@ -4134,7 +4193,7 @@ dependencies = [
  "blake2b_simd 1.0.1",
  "byteorder 1.4.3",
  "digest 0.10.7",
- "sha2 0.10.6",
+ "sha2 0.10.7",
  "sha3 0.10.8",
  "sp-std",
  "twox-hash",
@@ -4427,7 +4486,7 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.28",
  "serde 1.0.164",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "unicode-xid 0.2.4",
 ]
 
@@ -4440,7 +4499,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "substrate-api-client"
 version = "0.10.0"
-source = "git+https://github.com/scs/substrate-api-client.git?branch=polkadot-v0.9.42-tag-v0.10.0#686b7ef0aa8da255d3864a3fc703e32193813700"
+source = "git+https://github.com/scs/substrate-api-client.git?branch=polkadot-v0.9.42-tag-v0.10.0#6215a9e22e60f0651276d3cbf5a1c7fe0eaf84ed"
 dependencies = [
  "ac-compose-macros",
  "ac-node-api",
@@ -4451,7 +4510,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "serde 1.0.164",
- "serde_json 1.0.96",
+ "serde_json 1.0.97",
  "sp-core",
  "sp-runtime",
  "sp-runtime-interface",
@@ -4828,9 +4887,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
+checksum = "ca0ace3845f0d96209f0375e6d367e3eb87eb65d27d445bdc9f1843a26f39448"
 dependencies = [
  "memchr 2.5.0",
 ]

--- a/enclave-runtime/Cargo.toml
+++ b/enclave-runtime/Cargo.toml
@@ -27,6 +27,7 @@ teeracle = [
     "ita-oracle",
     "itp-settings/teeracle",
     "itp-top-pool-author/teeracle",
+    "encointer-primitives",
 ]
 test = [
     "ita-stf/test",
@@ -68,6 +69,8 @@ hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 ipfs-unixfs = { default-features = false, git = "https://github.com/whalelephant/rust-ipfs", branch = "w-nstd" }
 lazy_static = { version = "1.1.0", features = ["spin_no_std"] }
 primitive-types = { version = "0.12.1", default-features = false, features = ["codec", "serde_no_std"] }
+
+encointer-primitives = { branch = "polkadot-v0.9.42", git = "https://github.com/encointer/pallets", default-features = false, optional = true, features = ["full_crypto"] }
 
 # scs / integritee
 jsonrpc-core = { default-features = false, git = "https://github.com/scs/jsonrpc", branch = "no_std_v18" }

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -66,6 +66,8 @@ sgx-verify = { git = "https://github.com/integritee-network/pallets.git", branch
 substrate-api-client = { default-features = false, features = ["std", "ws-client"], git = "https://github.com/scs/substrate-api-client.git", branch = "polkadot-v0.9.42-tag-v0.10.0" }
 teerex-primitives = { git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.42" }
 
+encointer-primitives = { branch = "polkadot-v0.9.42", git = "https://github.com/encointer/pallets", default-features = false, optional = true, features = ["full_crypto"] }
+
 # Substrate dependencies
 frame-support = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 frame-system = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
@@ -81,7 +83,7 @@ evm = []
 sidechain = ["itp-settings/sidechain"]
 offchain-worker = ["itp-settings/offchain-worker"]
 production = ["itp-settings/production"]
-teeracle = ["itp-settings/teeracle"]
+teeracle = ["itp-settings/teeracle", "encointer-primitives"]
 dcap = []
 attesteer = []
 

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -18,7 +18,7 @@
 #![cfg_attr(test, feature(assert_matches))]
 
 #[cfg(feature = "teeracle")]
-use crate::teeracle::{schedule_periodic_reregistration_thread, start_periodic_market_update};
+use crate::teeracle::schedule_periodic_reregistration_thread;
 
 #[cfg(not(feature = "dcap"))]
 use crate::utils::check_files;
@@ -481,13 +481,6 @@ fn start_worker<E, T, D, InitializationHandler, WorkerModeProvider>(
 		schedule_periodic_reregistration_thread(
 			send_register_xt,
 			run_config.reregister_teeracle_interval(),
-		);
-
-		start_periodic_market_update(
-			&node_api,
-			run_config.teeracle_update_interval(),
-			enclave.as_ref(),
-			&teeracle_tokio_handle,
 		);
 	}
 

--- a/service/src/teeracle/mod.rs
+++ b/service/src/teeracle/mod.rs
@@ -17,14 +17,17 @@
 
 use crate::{error::ServiceResult, teeracle::schedule_periodic::schedule_periodic};
 use codec::{Decode, Encode};
+use encointer_primitives::{
+	ceremonies::Reputation, communities::CommunityIdentifier, scheduler::CeremonyIndexType,
+};
 use itp_enclave_api::teeracle_api::TeeracleApi;
 use itp_node_api::api_client::ParentchainApi;
-use itp_types::parentchain::Hash;
+use itp_types::parentchain::{AccountId, Hash};
 use itp_utils::hex::hex_encode;
 use log::*;
 use sp_runtime::OpaqueExtrinsic;
 use std::time::Duration;
-use substrate_api_client::{SubmitAndWatch, XtStatus};
+use substrate_api_client::{GetStorage, SubmitAndWatch, XtStatus};
 use teeracle_metrics::{increment_number_of_request_failures, set_extrinsics_inclusion_success};
 use tokio::runtime::Handle;
 


### PR DESCRIPTION
Currently draft PR.

This PR extends the CLI with a new subcommand `personhood-oracle fetch-reputation` which allows querying an account's reputation at a given cycle.

start the encointer node:
```
./target/release/encointer-node-notee --dev --tmp --ws-port 9945 --enable-offchain-indexing true --rpc-methods unsafe
```
run the bootstrapping script:
```
cd client && ./bootstrap_demo_community.py --port 9945
```

start the worker:
```
./integritee-service -p 9945 run --dev
```
run the 
```
#./integritee-cli -p <node_port> personhood-oracle fetch-reputation <account> <community_id> <ceremony_index>
./integritee-cli -p 9945 personhood-oracle fetch-reputation //Alice sqm1v79dF6b 1
```

TODO:
- [x] ~~Bump encointer/pallets to the same polkadot version~~ this will be separate issue
- [x] Query the last 5 cycles and count the number of valid reputations
- [ ] Verify read proof (done by SDK)
- [ ] Testing

Closes #3.